### PR TITLE
Add linux support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ set(LIBHAT_SRC
     src/arch/arm/System.cpp)
 
 add_library(libhat STATIC ${LIBHAT_SRC})
+if(UNIX)
+    set_target_properties(libhat PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
 
 target_include_directories(libhat PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>

--- a/include/libhat/Defines.hpp
+++ b/include/libhat/Defines.hpp
@@ -15,6 +15,8 @@
 // Detect Operating System
 #if defined(_WIN32)
     #define LIBHAT_WINDOWS
+#elif defined(__unix__) || defined(__unix) || defined(__APPLE__) || defined(__MACH__)
+    #define LIBHAT_UNIX
 #else
     #error Unsupported Operating System
 #endif

--- a/include/libhat/c/libhat.h
+++ b/include/libhat/c/libhat.h
@@ -1,9 +1,19 @@
 #pragma once
 
-#if defined(LIBHAT_BUILD_SHARED_LIB)
-    #define LIBHAT_API __declspec(dllexport)
-#elif defined(LIBHAT_USE_SHARED_LIB)
-    #define LIBHAT_API __declspec(dllimport)
+#if defined(LIBHAT_WINDOWS)
+    #if defined(LIBHAT_BUILD_SHARED_LIB)
+        #define LIBHAT_API __declspec(dllexport)
+    #elif defined(LIBHAT_USE_SHARED_LIB)
+        #define LIBHAT_API __declspec(dllimport)
+    #else
+        #define LIBHAT_API
+    #endif
+#elif defined(LIBHAT_UNIX)
+    #if defined(LIBHAT_BUILD_SHARED_LIB)
+        #define LIBHAT_API __attribute__((visibility("default")))
+    #else
+        #define LIBHAT_API
+    #endif
 #else
     #define LIBHAT_API
 #endif

--- a/src/c/libhat.cpp
+++ b/src/c/libhat.cpp
@@ -1,6 +1,7 @@
 #include <libhat/c/libhat.h>
 
 #include <libhat/Scanner.hpp>
+#include <cstring>
 
 static signature_t* allocate_signature(const hat::signature_view signature) {
     const auto bytes = std::as_bytes(signature);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,3 +24,6 @@ function(register_test NAME SOURCE)
 endfunction()
 
 register_test(libhat_benchmark_compare benchmark/Compare.cpp)
+
+add_executable(libhat_hwinfo info/HardwareInfo.cpp)
+target_link_libraries(libhat_hwinfo PRIVATE libhat)

--- a/test/info/HardwareInfo.cpp
+++ b/test/info/HardwareInfo.cpp
@@ -1,0 +1,28 @@
+#include <mutex>
+#include <random>
+#include <unordered_map>
+
+#include <libhat/System.hpp>
+
+int main(){
+	const auto& system = hat::get_system();
+	
+	printf("cpu_vendor: %s\n", system.cpu_vendor.c_str());
+	printf("cpu_brand: %s\n", system.cpu_brand.c_str());
+	// extensions
+	const auto& ext = system.extensions;
+	printf("sse: %d\n", ext.sse);
+	printf("sse2: %d\n", ext.sse2);
+	printf("sse3: %d\n", ext.sse3);
+	printf("ssse3: %d\n", ext.ssse3);
+	printf("sse41: %d\n", ext.sse41);
+	printf("sse42: %d\n", ext.sse42);
+	printf("avx: %d\n", ext.avx);
+	printf("avx2: %d\n", ext.avx2);
+	printf("avx512f: %d\n", ext.avx512f);
+	printf("avx512bw: %d\n", ext.avx512bw);
+	printf("popcnt: %d\n", ext.popcnt);
+	printf("bmi: %d\n", ext.bmi);
+
+	return 0;
+}


### PR DESCRIPTION
I have added support for unix systems by abstracting away cpuid and function exports.

I've also added an executable to test the new implementation of cpuid.

Had to add the position independent code because linux handles dynamic linking different than windows.

