### PR TITLE
Fix typedefs for c bingings

### DIFF
--- a/include/libhat/c/libhat.h
+++ b/include/libhat/c/libhat.h
@@ -60,14 +60,14 @@ LIBHAT_API const void* libhat_find_pattern(
     const signature_t*  signature,
     const void*         buffer,
     size_t              size,
-    scan_alignment      align
+    scan_alignment_t    align
 );
 
 LIBHAT_API const void* libhat_find_pattern_mod(
     const signature_t*  signature,
     const void*         module,
     const char*         section,
-    scan_alignment      align
+    scan_alignment_t    align
 );
 
 LIBHAT_API const void* libhat_get_module(const char* name);


### PR DESCRIPTION
```gcc errors for preamble:

./external/libhat/include/libhat/c/libhat.h:63:5: error: unknown type name 'scan_alignment'; did you mean 'scan_alignment_t'?
   63 |     scan_alignment      align
      |     ^~~~~~~~~~~~~~
      |     scan_alignment_t
./external/libhat/include/libhat/c/libhat.h:70:5: error: unknown type name 'scan_alignment'; did you mean 'scan_alignment_t'?
   70 |     scan_alignment      align
      |     ^~~~~~~~~~~~~~
      |     scan_alignment_t```

This fixes the C header file bindings for the enum `scan_alignment_t`