### PR TITLE
Fix falsely documented function usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ hat::scan_result result = hat::find_pattern(pattern, ".text");
 // Or another module loaded into the process
 std::optional<hat::process::module> ntdll = hat::process::get_module("ntdll.dll");
 assert(ntdll.has_value());
-hat::scan_result result = hat::find_pattern(pattern, *ntdll, ".text");
+hat::scan_result result = hat::find_pattern(pattern, ".text", *ntdll);
 
 // Get the address pointed at by the pattern
 const std::byte* address = result.get();


### PR DESCRIPTION
Before this commit an example of the find_pattern overload that takes a process::module was used as:
`hat::find_pattern(pattern, *ntdll, ".text");`

However, the correct usage of this is:
`hat::find_pattern(pattern, ".text", *ntdll);`

This has been rectified with this commit.